### PR TITLE
fixes validator `menu_id` required

### DIFF
--- a/src/app/Http/Requests/ValidateRoleRequest.php
+++ b/src/app/Http/Requests/ValidateRoleRequest.php
@@ -18,7 +18,7 @@ class ValidateRoleRequest extends FormRequest
             'name' => ['required', $this->nameUnique()],
             'display_name' => 'required',
             'description' => 'nullable',
-            'menu_id' => 'nullable|exists:menus,id',
+            'menu_id' => 'required|exists:menus,id',
         ];
     }
 


### PR DESCRIPTION
Having roles without default menus causes errors in: 
https://github.com/laravel-enso/core/blob/master/src/app/Http/Responses/AppState.php#L47